### PR TITLE
move resource server to common.separate Bean  for LDAP and DB

### DIFF
--- a/dummy-resource-server/src/main/java/com/flytxt/dummy/DummyResourceServer.java
+++ b/dummy-resource-server/src/main/java/com/flytxt/dummy/DummyResourceServer.java
@@ -3,11 +3,17 @@ package com.flytxt.dummy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+import com.flytxt.security.rsc.JwtConfig;
+import com.flytxt.security.rsc.ResourceServerConfig;
 
 @SpringBootApplication
+@Import({ResourceServerConfig.class,JwtConfig.class})
 public class DummyResourceServer {
 
-	public static void main(String[] args) {
+	public static void main(String[] args) {		
+		
 		SpringApplication.run(DummyResourceServer.class, args);
 	}
 }

--- a/dummy-resource-server/src/main/java/com/flytxt/dummy/WebController.java
+++ b/dummy-resource-server/src/main/java/com/flytxt/dummy/WebController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/foo")
 public class WebController {
 
-    @PreAuthorize("hasAuthority('FOO_READ')")
+    @PreAuthorize("hasAuthority('shiju.john')")
     @RequestMapping(method = RequestMethod.GET)
     public String readFoo() {
         return "read foo " + UUID.randomUUID().toString();

--- a/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/AuthenticationType.java
+++ b/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/AuthenticationType.java
@@ -1,0 +1,20 @@
+package com.flytxt.security.jwtoauthserver;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+
+/**
+ * 
+ * @author shiju.john
+ *
+ */
+@Configuration
+public interface AuthenticationType { 
+	
+	/**
+	 * For setting the authentication type 
+	 * @throws Exception
+	 */
+	public void setAuthenticationManager(AuthenticationManagerBuilder auth)  throws Exception;
+
+}

--- a/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/DBAuthenticationBuilder.java
+++ b/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/DBAuthenticationBuilder.java
@@ -1,0 +1,32 @@
+package com.flytxt.security.jwtoauthserver;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+/**
+ * 
+ * @author shiju.john
+ *
+ */
+@Profile("db")
+@Configuration
+public class DBAuthenticationBuilder implements AuthenticationType{
+
+	
+	@Autowired
+	DataSource dataSource;
+	
+	
+
+	@Override
+	public void setAuthenticationManager(AuthenticationManagerBuilder auth) throws Exception {
+		auth.jdbcAuthentication().dataSource(dataSource)
+		.usersByUsernameQuery("select username,password, enabled from users where username=?")
+		.authoritiesByUsernameQuery("select username, role from user_roles where username=?");
+		
+	}
+
+}

--- a/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/LdapAuthenticationBuilder.java
+++ b/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/LdapAuthenticationBuilder.java
@@ -1,0 +1,35 @@
+package com.flytxt.security.jwtoauthserver;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
+
+@Profile("ldap")
+@Configuration
+@EnableConfigurationProperties
+public class LdapAuthenticationBuilder implements AuthenticationType{
+	
+	/** LDAP Directory Domain */
+	@Value("${authentication.mode.ldap.activeDirectoryDomain}")
+    private String activeDirectoryDomain;
+	
+	/** LDAP Directory URL  */
+	@Value("${authentication.mode.ldap.activeDirectoryUrl}")
+    private String activeDirectoryUrl;
+	
+	
+	@Override
+	public void setAuthenticationManager(AuthenticationManagerBuilder auth) {
+		ActiveDirectoryLdapAuthenticationProvider provider = new ActiveDirectoryLdapAuthenticationProvider(
+				activeDirectoryDomain, activeDirectoryUrl);
+		provider.setConvertSubErrorCodesToExceptions(true);
+	    provider.setUseAuthenticationRequestCredentials(true);		     
+		auth.authenticationProvider(provider);		
+	}
+	
+	
+
+}

--- a/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/OAuth2Config.java
+++ b/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/OAuth2Config.java
@@ -21,8 +21,9 @@ import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFacto
 @Configuration
 @EnableAuthorizationServer
 public class OAuth2Config extends AuthorizationServerConfigurerAdapter {
-   @Autowired
-   DataSource dataSource;
+  
+	@Autowired
+	DataSource dataSource;
 
     @Autowired
     @Qualifier("authenticationManagerBean")

--- a/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/WebSecurityConfig.java
+++ b/jwt-aouth-server/src/main/java/com/flytxt/security/jwtoauthserver/WebSecurityConfig.java
@@ -1,50 +1,27 @@
 package com.flytxt.security.jwtoauthserver;
 
 import javax.servlet.http.HttpServletResponse;
-import javax.sql.DataSource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
 
 @Configuration
-@EnableConfigurationProperties
 class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
 	Logger log = LoggerFactory.getLogger(WebSecurityConfig.class);
 	
-	private static final String LDAP_KEY ="LDAP"; 
-    
-	/** for checking the authentication.Possible values are   
-	 * 	
-	 *  1.  LDAP -  For LDAP validation .
-	 *  2.  DB - USer details from DB  
-	 *  
-	 *  **/
-	@Value("${authentication.mode}")
-    private String authenticationMode;
-	
-	
-	/** LDAP Directory Domain  eg. flytxt.com*/
-	@Value("${authentication.mode.ldap.activeDirectoryDomain}")
-    private String activeDirectoryDomain;
-	
-	/** LDAP Directory URL eg :  ldap://serverIP:389 */
-	@Value("${authentication.mode.ldap.activeDirectoryUrl}")
-    private String activeDirectoryUrl;
-	
-	
 	@Autowired
-	DataSource dataSource;
-
+	AuthenticationType authType;
+	
+	
+	
 	@Override
 	@Bean
 	public AuthenticationManager authenticationManagerBean() throws Exception {
@@ -57,30 +34,10 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 				.authenticationEntryPoint(
 						(request, response, authException) -> response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
 				.and().authorizeRequests().antMatchers("/**").authenticated().and().httpBasic();
-		/*
-		http.formLogin().loginPage("/login").permitAll().and()
-				.requestMatchers().antMatchers( "/oauth/authorize", "/oauth/confirm_access","/oauth/token",
-						"/oauth/check_token","/oauth/token_key","/console")
-				.and()
-				.authorizeRequests().anyRequest().authenticated();*/
 	}
 
 	@Override
 	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-		
-		if(LDAP_KEY.equalsIgnoreCase(authenticationMode)){
-			
-			ActiveDirectoryLdapAuthenticationProvider provider = new ActiveDirectoryLdapAuthenticationProvider(
-					activeDirectoryDomain, activeDirectoryUrl);
-			provider.setConvertSubErrorCodesToExceptions(true);
-		    provider.setUseAuthenticationRequestCredentials(true);		     
-			auth.authenticationProvider(provider);
-			//auth.parentAuthenticationManager(authenticationManagerBean());
-		}else{					
-			auth.jdbcAuthentication().dataSource(dataSource)
-			.usersByUsernameQuery("select username,password, enabled from users where username=?")
-			.authoritiesByUsernameQuery("select username, role from user_roles where username=?");
-		}		
-		
+		authType.setAuthenticationManager(auth);		
 	}
 }

--- a/jwt-aouth-server/src/main/resources/application.properties
+++ b/jwt-aouth-server/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 logging.level.org.springframework.*: DEBUG
-authentication.mode=DB
+spring.profiles.active=db
 authentication.mode.ldap.activeDirectoryDomain=flytxt.com
 authentication.mode.ldap.activeDirectoryUrl=ldap://192.168.125.10:389
+

--- a/resource-server-config/src/main/java/com/flytxt/security/rsc/ResourceServerConfig.java
+++ b/resource-server-config/src/main/java/com/flytxt/security/rsc/ResourceServerConfig.java
@@ -1,10 +1,9 @@
-package com.flytxt.dummy;
+package com.flytxt.security.rsc;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
@@ -12,11 +11,8 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Res
 import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 
-import com.flytxt.security.rsc.JwtConfig;
-
 @Configuration
 @EnableResourceServer
-@Import(JwtConfig.class)
 @EnableConfigurationProperties
 public class ResourceServerConfig extends ResourceServerConfigurerAdapter{
 	
@@ -42,12 +38,6 @@ public class ResourceServerConfig extends ResourceServerConfigurerAdapter{
         .csrf().disable()
         .authorizeRequests()        
         .and().authorizeRequests().antMatchers("/**").authenticated();
-        
-        /*.antMatchers("/**").authenticated()
-        .antMatchers(HttpMethod.GET, "/foo").hasAuthority("FOO_READ")
-        .antMatchers(HttpMethod.POST, "/foo").hasAuthority("FOO_WRITE");*/
-
-		
     }
 	
 }

--- a/resource-server-config/src/main/resources/application.yml
+++ b/resource-server-config/src/main/resources/application.yml
@@ -1,2 +1,0 @@
-server:
-  port: 9001


### PR DESCRIPTION
Please review the below changes 

1. move the resource server to common from Dummy Resource server 
2.  Separate bean configuration  for LDAP and DB authentication. 